### PR TITLE
MB4-73: Implement the matrix list page for unpublished projects - Moved ProjectSideNav so that used across private and public projects

### DIFF
--- a/src/components/project/ProjectLoaderComp.vue
+++ b/src/components/project/ProjectLoaderComp.vue
@@ -1,9 +1,9 @@
 <script setup>
-import ProjectSideNav from '@/views/project/ProjectSideNav.vue'
+import ProjectSideNav from '@/components/project/ProjectSideNav.vue'
 import ProjectTitleComp from '@/components/project/ProjectTitleComp.vue'
 
 const props = defineProps({
-  project_id: {
+  projectId: {
     type: [Number, String],
     required: true,
   },
@@ -13,6 +13,10 @@ const props = defineProps({
   },
   errorMessage: String,
   itemName: {
+    type: String,
+    required: true,
+  },
+  basePath: {
     type: String,
     required: true,
   },
@@ -28,18 +32,19 @@ const props = defineProps({
     <div class="row">
       <div class="col-2 border-end">
         <ProjectSideNav
-          :project_id="project_id"
+          :projectId="projectId"
           :item="itemName"
+          :basePath="basePath"
         ></ProjectSideNav>
       </div>
 
       <div class="col-10">
-        <div v-if="!errorMessage">
-          <ProjectTitleComp></ProjectTitleComp>
-          <slot />
+        <div v-if="errorMessage">
+          <strong>{{ errorMessage }}</strong>
         </div>
         <div v-else>
-          <strong>{{ errorMessage }}</strong>
+          <ProjectTitleComp></ProjectTitleComp>
+          <slot />
         </div>
       </div>
     </div>

--- a/src/components/project/ProjectSideNav.vue
+++ b/src/components/project/ProjectSideNav.vue
@@ -2,11 +2,15 @@
 import { RouterLink } from 'vue-router'
 
 const props = defineProps({
-  project_id: {
+  projectId: {
     type: [Number, String],
     required: true,
   },
   item: {
+    type: String,
+    required: true,
+  },
+  basePath: {
     type: String,
     required: true,
   },
@@ -16,8 +20,10 @@ const props = defineProps({
 <template>
   <div class="nav-link mb-1 d-flex fw-bold small m-0 p-0 mb-3">
     <i class="bi bi-chevron-double-left me-1"></i>
-    <RouterLink class="nav-link m-0 p-0" :to="`/project`">
-      Browse projects
+    <RouterLink class="nav-link m-0 p-0" :to="`/${basePath}`">
+      <span v-if="basePath == 'project'">Browse projects</span>
+      <span v-else>My projects</span>
+      
     </RouterLink>
   </div>
 
@@ -32,7 +38,7 @@ const props = defineProps({
     >
       <RouterLink
         class="nav-link m-0 p-0"
-        :to="`/project/${project_id}/overview`"
+        :to="`/${basePath}/${projectId}/overview`"
       >
         Project Overview
       </RouterLink>
@@ -48,7 +54,7 @@ const props = defineProps({
     >
       <RouterLink
         class="nav-link m-0 p-0"
-        :to="`/project/${project_id}/matrices`"
+        :to="`/${basePath}/${projectId}/matrices`"
       >
         Matrices
       </RouterLink>
@@ -60,7 +66,7 @@ const props = defineProps({
         'list-group-item',
       ]"
     >
-      <RouterLink class="nav-link m-0 p-0" :to="`/project/${project_id}/media`"
+      <RouterLink class="nav-link m-0 p-0" :to="`/${basePath}/${projectId}/media`"
         >Media</RouterLink
       >
     </li>
@@ -73,7 +79,7 @@ const props = defineProps({
         'list-group-item',
       ]"
     >
-      <RouterLink class="nav-link m-0 p-0" :to="`/project/${project_id}/views`"
+      <RouterLink class="nav-link m-0 p-0" :to="`/${basePath}/${projectId}/views`"
         >Views of Media</RouterLink
       >
     </li>
@@ -88,7 +94,7 @@ const props = defineProps({
     >
       <RouterLink
         class="nav-link m-0 p-0"
-        :to="`/project/${project_id}/specimens`"
+        :to="`/${basePath}/${projectId}/specimens`"
       >
         Specimens
       </RouterLink>
@@ -100,7 +106,7 @@ const props = defineProps({
         'list-group-item',
       ]"
     >
-      <RouterLink class="nav-link m-0 p-0" :to="`/project/${project_id}/taxa`">
+      <RouterLink class="nav-link m-0 p-0" :to="`/${basePath}/${projectId}/taxa`">
         Taxa
       </RouterLink>
     </li>
@@ -115,7 +121,7 @@ const props = defineProps({
     >
       <RouterLink
         class="nav-link m-0 p-0"
-        :to="`/project/${project_id}/bibliography`"
+        :to="`/${basePath}/${projectId}/bibliography`"
       >
         Bibliography
       </RouterLink>
@@ -131,7 +137,7 @@ const props = defineProps({
     >
       <RouterLink
         class="nav-link m-0 p-0"
-        :to="`/project/${project_id}/documents`"
+        :to="`/${basePath}/${projectId}/documents`"
       >
         Documents
       </RouterLink>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,39 +1,38 @@
 import { useAuthStore } from '@/stores/storeAuth.js'
 import { createRouter, createWebHistory } from 'vue-router'
 
-import HomeView from '../views/HomeView.vue'
-import ProjectOverviewView from '@/views/project/ProjectOverviewView.vue'
-import ProjectTaxaView from '@/views/project/ProjectTaxaView.vue'
-import ProjectsHomeView from '@/views/project/ProjectsHomeView.vue'
-import ProjectTitleView from '@/views/project/ProjectTitleView.vue'
-import ProjectPopularView from '@/views/project/ProjectPopularView.vue'
+import AdminHomeView from '@/views/admin/AdminHomeView.vue'
+import AdminView from '@/views/admin/AdminView.vue'
+import AskUsView from '@/views/misc/AskUsView.vue'
+import CuratorHomeView from '@/views/curator/CuratorHomeView.vue'
+import CuratorView from '@/views/curator/CuratorView.vue'
+import DocsView from '@/views/misc/DocsView.vue'
+import FaqView from '@/views/misc/FaqView.vue'
+import HomeView from '@/views/HomeView.vue'
+import MyProjectHomeView from '@/views/project/MyProjectHomeView.vue'
+import MyProjectMatrixView from '@/views/project/MyProjectMatrixView.vue'
+import MyProjectsView from '@/views/project/MyProjectsView.vue'
+import NewsView from '@/views/misc/NewsView.vue'
+import NotFoundView from '@/views/NotFoundView.vue'
 import ProjectAuthorView from '@/views/project/ProjectAuthorView.vue'
-import ProjectJournalView from '@/views/project/ProjectJournalView.vue'
-import ProjectInstitutionView from '@/views/project/ProjectInstitutionView.vue'
 import ProjectBibliographyView from '@/views/project/ProjectBibliographyView.vue'
 import ProjectDocumentView from '@/views/project/ProjectDocumentView.vue'
+import ProjectInstitutionView from '@/views/project/ProjectInstitutionView.vue'
+import ProjectJournalView from '@/views/project/ProjectJournalView.vue'
 import ProjectMatrixView from '@/views/project/ProjectMatrixView.vue'
 import ProjectMediaView from '@/views/project/ProjectMediaView.vue'
 import ProjectMediaViewsView from '@/views/project/ProjectMediaViewsView.vue'
+import ProjectOverviewView from '@/views/project/ProjectOverviewView.vue'
+import ProjectPopularView from '@/views/project/ProjectPopularView.vue'
 import ProjectSpecimenView from '@/views/project/ProjectSpecimenView.vue'
-import NotFoundView from '@/views/NotFoundView.vue'
-import UserLogin from '@/views/users/UserLogin.vue'
-import UserView from '@/views/users/UserView.vue'
-
-import AdminHomeView from '@/views/admin/AdminHomeView.vue'
+import ProjectTaxaView from '@/views/project/ProjectTaxaView.vue'
+import ProjectTitleView from '@/views/project/ProjectTitleView.vue'
 import ProjectView from '@/views/project/ProjectView.vue'
-import MyProjectsView from '@/views/project/MyProjectsView.vue'
-import MyProjectHomeView from '@/views/project/MyProjectHomeView.vue'
-import MyProjectMatrixView from '@/views/project/MyProjectMatrixView.vue'
+import ProjectsHomeView from '@/views/project/ProjectsHomeView.vue'
+import UserLogin from '@/views/users/UserLogin.vue'
 import UserProfileView from '@/views/users/UserProfileView.vue'
 import UserRegistrationView from '@/views/users/UserRegistrationView.vue'
-import AskUsView from '@/views/misc/AskUsView.vue'
-import DocsView from '@/views/misc/DocsView.vue'
-import FaqView from '@/views/misc/FaqView.vue'
-import NewsView from '@/views/misc/NewsView.vue'
-import AdminView from '@/views/admin/AdminView.vue'
-import CuratorHomeView from '@/views/curator/CuratorHomeView.vue'
-import CuratorView from '@/views/curator/CuratorView.vue'
+import UserView from '@/views/users/UserView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -133,7 +132,7 @@ const router = createRouter({
       ],
     },
 
-    // projects
+    // User's Projects
     {
       path: '/myprojects',
       name: 'MyProjectsView',
@@ -157,10 +156,11 @@ const router = createRouter({
         },
       ],
     },
+
+    // Public view of Projects
     {
       path: '/project',
       component: ProjectView,
-
       children: [
         {
           path: 'pub_date',
@@ -202,7 +202,6 @@ const router = createRouter({
           name: 'ProjectInstitutionView',
           component: ProjectInstitutionView,
         },
-
         {
           path: ':id/overview',
           name: 'ProjectOverviewView',
@@ -245,7 +244,6 @@ const router = createRouter({
         },
       ],
     },
-
     {
       path: '/:catchAll(.*)',
       component: NotFoundView,

--- a/src/views/project/MyProjectMatrixView.vue
+++ b/src/views/project/MyProjectMatrixView.vue
@@ -1,3 +1,24 @@
+<script setup>
+import { onMounted } from 'vue'
+import ProjectLoaderComp from '../../components/project/ProjectLoaderComp.vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+const projectId = route.params.id
+
+onMounted(() => {
+
+})
+</script>
+
 <template>
-  <h1>My Matrices</h1>
+  <ProjectLoaderComp 
+    :projectId="projectId"
+    :isLoading="false"
+    :errorMessage="null" 
+    basePath="myprojects" 
+    itemName="matrices">
+    Nothing here!
+  </ProjectLoaderComp>
 </template>

--- a/src/views/project/ProjectBibliographyView.vue
+++ b/src/views/project/ProjectBibliographyView.vue
@@ -6,7 +6,7 @@ import { useRoute } from 'vue-router'
 const route = useRoute()
 
 const projectStore = useProjectStore()
-const project_id = route.params.id
+const projectId = route.params.id
 
 onMounted(() => {
   projectStore.fetchProject(project_id)
@@ -15,11 +15,12 @@ onMounted(() => {
 
 <template>
   <ProjectLoaderComp
-    :project_id="project_id"
+    :projectId="projectId"
     :isLoading="projectStore.isLoading"
     :errorMessage="
       projectStore.bibliography ? null : 'No bibliography data available.'
     "
+    basePath="project"
     itemName="bibliography"
   >
     This project has {{ projectStore.bibliography?.length }} bibliographic

--- a/src/views/project/ProjectDocumentView.vue
+++ b/src/views/project/ProjectDocumentView.vue
@@ -6,17 +6,19 @@ import { useRoute } from 'vue-router'
 const route = useRoute()
 
 const projectStore = useProjectStore()
-const project_id = route.params.id
+const projectId = route.params.id
+
 onMounted(() => {
-  projectStore.fetchProject(project_id)
+  projectStore.fetchProject(projectId)
 })
 </script>
 
 <template>
   <ProjectLoaderComp
-    :project_id="project_id"
+    :projectId="projectId"
     :isLoading="projectStore.isLoading"
     :errorMessage="projectStore.docs ? null : 'No documents data available.'"
+    basePath="project"
     itemName="documents"
   >
     <div :key="n" v-for="(fld, n) in projectStore.docs">

--- a/src/views/project/ProjectMatrixView.vue
+++ b/src/views/project/ProjectMatrixView.vue
@@ -6,17 +6,19 @@ import { useRoute } from 'vue-router'
 const route = useRoute()
 
 const projectStore = useProjectStore()
-const project_id = route.params.id
+const projectId = route.params.id
+
 onMounted(() => {
-  projectStore.fetchProject(project_id)
+  projectStore.fetchProject(projectId)
 })
 </script>
 
 <template>
   <ProjectLoaderComp
-    :project_id="project_id"
+    :projectId="projectId"
     :isLoading="projectStore.isLoading"
     :errorMessage="projectStore.matrices ? null : 'No matrix data available.'"
+    basePath="project"
     itemName="matrices"
   >
     {{ projectStore.matrices }}

--- a/src/views/project/ProjectMediaView.vue
+++ b/src/views/project/ProjectMediaView.vue
@@ -9,11 +9,11 @@ import { useRoute } from 'vue-router'
 const route = useRoute()
 
 const mediaStore = useMediaStore()
-const project_id = route.params.id
+const projectId = route.params.id
 let mediaDetailsFor = ref(null)
 
 onMounted(() => {
-  mediaStore.fetchMediaFiles(project_id)
+  mediaStore.fetchMediaFiles(projectId)
 })
 
 let isDetailsActive = ref(false)
@@ -40,9 +40,10 @@ watch(selectedPageSize, (currentValue, oldValue) => {
 
 <template>
   <ProjectLoaderComp
-    :project_id="project_id"
+    :projectId="projectId"
     :isLoading="mediaStore.isLoading"
     :errorMessage="mediaStore.media_files ? null : 'No media data available.'"
+    basePath="project"
     itemName="media"
   >
     <p>

--- a/src/views/project/ProjectMediaViewsView.vue
+++ b/src/views/project/ProjectMediaViewsView.vue
@@ -3,21 +3,24 @@ import { onMounted } from 'vue'
 import { useProjectStore } from '@/stores/storeProjectDetails.js'
 import ProjectLoaderComp from '../../components/project/ProjectLoaderComp.vue'
 import { useRoute } from 'vue-router'
+
 const route = useRoute()
 const projectStore = useProjectStore()
-const project_id = route.params.id
+const projectId = route.params.id
+
 onMounted(() => {
-  projectStore.fetchProject(project_id)
+  projectStore.fetchProject(projectId)
 })
 </script>
 
 <template>
   <ProjectLoaderComp
-    :project_id="project_id"
+    :projectId="projectId"
     :isLoading="projectStore.isLoading"
     :errorMessage="
       projectStore.media_views ? null : 'No media views data available.'
     "
+    basePath="project"
     itemName="media_views"
   >
     <ul class="list-group">

--- a/src/views/project/ProjectOverviewView.vue
+++ b/src/views/project/ProjectOverviewView.vue
@@ -8,21 +8,24 @@ import ProjectTaxa from './overview/ProjectTaxa.vue'
 import { useProjectStore } from '@/stores/storeProjectDetails.js'
 import ProjectLoaderComp from '../../components/project/ProjectLoaderComp.vue'
 import { useRoute } from 'vue-router'
+
 const route = useRoute()
 const projectStore = useProjectStore()
-const project_id = route.params.id
+const projectId = route.params.id
+
 onMounted(() => {
-  projectStore.fetchProject(project_id)
+  projectStore.fetchProject(projectId)
 })
 </script>
 <template>
   <ProjectLoaderComp
-    :key="project_id"
-    :project_id="project_id"
+    :key="projectId"
+    :projectId="projectId"
     :isLoading="projectStore.isLoading"
     :errorMessage="
       projectStore.overview ? null : 'No project overview data available.'
     "
+    basePath="project"
     itemName="overview"
   >
     <div class="pb-5 border-bottom"><ProjectSummary></ProjectSummary></div>

--- a/src/views/project/ProjectSpecimenView.vue
+++ b/src/views/project/ProjectSpecimenView.vue
@@ -3,22 +3,24 @@ import { onMounted } from 'vue'
 import ProjectLoaderComp from '../../components/project/ProjectLoaderComp.vue'
 import { useProjectStore } from '@/stores/storeProjectDetails.js'
 import { useRoute } from 'vue-router'
+
 const route = useRoute()
-const project_id = route.params.id
+const projectId = route.params.id
 const projectStore = useProjectStore()
 
 onMounted(() => {
-  projectStore.fetchProject(project_id)
+  projectStore.fetchProject(projectId)
 })
 </script>
 
 <template>
   <ProjectLoaderComp
-    :project_id="project_id"
+    :projectId="projectId"
     :isLoading="projectStore.isLoading"
     :errorMessage="
       projectStore.specimen_details ? null : 'No specimen data available.'
     "
+    basePath="project"
     itemName="specimens"
   >
     <p>

--- a/src/views/project/ProjectTaxaView.vue
+++ b/src/views/project/ProjectTaxaView.vue
@@ -3,20 +3,22 @@ import { onMounted } from 'vue'
 import { useProjectStore } from '@/stores/storeProjectDetails.js'
 import ProjectLoaderComp from '../../components/project/ProjectLoaderComp.vue'
 import { useRoute } from 'vue-router'
+
 const route = useRoute()
-const project_id = route.params.id
+const projectId = route.params.id
 const projectStore = useProjectStore()
 
 onMounted(() => {
-  projectStore.fetchProject(project_id)
+  projectStore.fetchProject(projectId)
 })
 </script>
 
 <template>
   <ProjectLoaderComp
-    :project_id="project_id"
+    :projectId="projectId"
     :isLoading="projectStore.isLoading"
     :errorMessage="projectStore.taxa_details ? null : 'No taxa data available.'"
+    basePath="project"
     itemName="taxa"
   >
     <p>


### PR DESCRIPTION
* Moved ProjectSideNav so that used across private and public projects
* Also reordered the imports to alphabetical order
* Rename project_id to projectId to match in ProjectSideNav and ProjectLoaderComp 