### PR TITLE
Delete member group

### DIFF
--- a/src/components/project/MembersGroupsComp.vue
+++ b/src/components/project/MembersGroupsComp.vue
@@ -7,6 +7,7 @@ type Group = {
 
 const props = defineProps<{
   groups: Group[]
+  deleteGroup: Group
 }>()
 </script>
 
@@ -21,7 +22,17 @@ const props = defineProps<{
         <div class="list-group-item-name">
           {{ group.group_name }}
         </div>
-        <div class="list-group-item-buttons"></div>
+        <div class="list-group-item-buttons">
+          <button
+            type="button"
+            class="btn btn-sm btn-secondary"
+            data-bs-toggle="modal"
+            data-bs-target="#groupDeleteModal"
+            @click="$emit('update:deleteGroup', group)"
+          >
+            <i class="fa-regular fa-trash-can"></i>
+          </button>
+        </div>
       </div>
       <div>
         {{ group.description }}
@@ -32,6 +43,10 @@ const props = defineProps<{
 <style scoped>
 .list-group-item-header {
   display: flex;
+}
+.list-group-item-buttons {
+  display: flex;
+  gap: 7px;
 }
 .list-group-item-name {
   display: flex;

--- a/src/stores/ProjectMemberGroupsStore.js
+++ b/src/stores/ProjectMemberGroupsStore.js
@@ -27,6 +27,27 @@ export const useProjectMemberGroupsStore = defineStore({
       }
       return null
     },
+    async deleteGroup(projectId, groupId) {
+      const url = `${
+        import.meta.env.VITE_API_URL
+      }/projects/${projectId}/groups/delete`
+      const response = await axios.post(url, {
+        group_id: groupId,
+      })
+      if (response.status == 200) {
+        this.removeGroupById(groupId)
+        return true
+      }
+      return false
+    },
+    removeGroupById(groupId) {
+      for (let x = 0; x < this.groups.length; ++x) {
+        if (groupId == this.groups[x].group_id) {
+          this.groups.splice(x, 1)
+          break
+        }
+      }
+    },
     invalidate() {
       this.isLoaded = false
       this.users = []

--- a/src/views/project/membersGroups/DeleteGroupDialog.vue
+++ b/src/views/project/membersGroups/DeleteGroupDialog.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { useProjectMemberGroupsStore } from '@/stores/ProjectMemberGroupsStore'
+
+const props = defineProps<{
+  projectId: number | string
+  group?: any
+}>()
+const projectMemberGroupsStore = useProjectMemberGroupsStore()
+async function deleteGroup(groupId: number) {
+  const deleted = await projectMemberGroupsStore.deleteGroup(
+    props.projectId,
+    groupId
+  )
+  if (!deleted) {
+    alert('Failed to delete group')
+  }
+}
+</script>
+<template>
+  <div class="modal" id="groupDeleteModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Confirm</h5>
+        </div>
+        <div class="modal-body">
+          Really delete group: <i>{{ group.group_name }}</i> ?
+        </div>
+        <div class="modal-footer">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            data-bs-dismiss="modal"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-bs-dismiss="modal"
+            @click="deleteGroup(group.group_id)"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/project/membersGroups/ListView.vue
+++ b/src/views/project/membersGroups/ListView.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router'
 import { useProjectMemberGroupsStore } from '@/stores/ProjectMemberGroupsStore'
 import LoadingIndicator from '@/components/project/LoadingIndicator.vue'
 import MembersGroupsComp from '@/components/project/MembersGroupsComp.vue'
+import DeleteGroupDialog from './DeleteGroupDialog.vue'
 
 const route = useRoute()
 const projectId = route.params.id
@@ -11,6 +12,7 @@ const projectId = route.params.id
 const projectMemberGroupsStore = useProjectMemberGroupsStore()
 const isLoaded = computed(() => projectMemberGroupsStore.isLoaded)
 const numOfGroups = computed(() => projectMemberGroupsStore.groups?.length)
+const groupToDelete = ref({})
 
 onMounted(() => {
   if (!projectMemberGroupsStore.isLoaded) {
@@ -37,6 +39,8 @@ onMounted(() => {
     </div>
     <MembersGroupsComp
       :groups="projectMemberGroupsStore.groups"
+      v-model:deleteGroup="groupToDelete"
     ></MembersGroupsComp>
   </LoadingIndicator>
+  <DeleteGroupDialog :group="groupToDelete" :projectId="projectId" />
 </template>


### PR DESCRIPTION
Added a delete modal that pops up when a user clicks the delete button on a group and a delete method in the ProjectMemberGroupsStore. This allows the user to interact with the client and delete a member group from the database, which also updates on the client side.