### PR TITLE
Annotation Viewer lots of improvements and bug fixes

### DIFF
--- a/src/components/media/ConfirmModal.vue
+++ b/src/components/media/ConfirmModal.vue
@@ -1,0 +1,283 @@
+<template>
+  <div class="modal-overlay" @click.self="cancel">
+    <div class="modal-container">
+      <div class="modal-header">
+        <h3 class="modal-title">{{ title }}</h3>
+        <button class="modal-close" @click="cancel" title="Close">✕</button>
+      </div>
+      
+      <div class="modal-body">
+        <p class="modal-message">{{ message }}</p>
+      </div>
+      
+      <div class="modal-footer">
+        <button 
+          class="btn btn-secondary" 
+          @click="cancel"
+          :disabled="loading"
+        >
+          {{ cancelText }}
+        </button>
+        <button 
+          class="btn btn-primary" 
+          @click="confirm"
+          :disabled="loading"
+        >
+          <span v-if="loading" class="btn-spinner"></span>
+          <span v-else>{{ confirmText }}</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ConfirmModal',
+  
+  props: {
+    title: {
+      type: String,
+      default: 'Confirm Action'
+    },
+    message: {
+      type: String,
+      required: true
+    },
+    confirmText: {
+      type: String,
+      default: 'Confirm'
+    },
+    cancelText: {
+      type: String,
+      default: 'Cancel'
+    },
+    loading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  
+  mounted() {
+    // Add escape key listener
+    document.addEventListener('keydown', this.handleEscape)
+  },
+  
+  beforeUnmount() {
+    document.removeEventListener('keydown', this.handleEscape)
+  },
+  
+  methods: {
+    confirm() {
+      if (!this.loading) {
+        this.$emit('confirm')
+      }
+    },
+    
+    cancel() {
+      if (!this.loading) {
+        this.$emit('cancel')
+      }
+    },
+    
+    handleEscape(event) {
+      if (event.key === 'Escape' && !this.loading) {
+        this.cancel()
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100000;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.modal-container {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  width: 90%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow: hidden;
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.modal-header {
+  padding: 20px 24px;
+  border-bottom: 1px solid #e9ecef;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f8f9fa;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #6c757d;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.modal-close:hover {
+  background: #e9ecef;
+  color: #495057;
+}
+
+.modal-body {
+  padding: 24px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.modal-message {
+  font-size: 15px;
+  line-height: 1.6;
+  color: #495057;
+  margin: 0;
+}
+
+.modal-footer {
+  padding: 16px 24px;
+  border-top: 1px solid #e9ecef;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  background: #f8f9fa;
+}
+
+.btn {
+  padding: 10px 20px;
+  border: 1px solid #ccc;
+  background: white;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: all 0.2s;
+  min-width: 100px;
+  height: 40px;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #0056b3;
+  border-color: #0056b3;
+}
+
+.btn-secondary {
+  background: #6c757d;
+  color: white;
+  border-color: #6c757d;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: #545b62;
+  border-color: #545b62;
+}
+
+.btn-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Responsive design */
+@media (max-width: 600px) {
+  .modal-container {
+    width: 95%;
+    max-width: none;
+  }
+  
+  .modal-header,
+  .modal-body,
+  .modal-footer {
+    padding: 16px;
+  }
+  
+  .modal-title {
+    font-size: 16px;
+  }
+  
+  .modal-message {
+    font-size: 14px;
+  }
+  
+  .btn {
+    min-width: 80px;
+    padding: 8px 16px;
+  }
+}
+</style>
+


### PR DESCRIPTION
## Features Added

1. **Label Drag Confirmation** - Created custom modal that prompts users to save or cancel when they drag a label to a new position (replaces browser confirm dialog)

2. **Hide All Labels Button** - Added toggle button to hide all labels and connection lines, useful for viewing clean annotations without clutter

3. **Fixed Missing Labels Bug** - Annotations with `showDefaultText=0` now always show in numbered mode (previously disappeared completely in read-only)

4. **Fixed String "true" Bug** - Backend now normalizes `showDefaultText` to integer 1/0, frontend now handles string "true" values correctly

5. **Updated Help Documentation** - Added instructions for new hide labels feature and label dragging with save confirmation