### PR TITLE
MB4-425: add side info to media tooltip and fix 3D viewer rotation

### DIFF
--- a/src/components/project/ThreeJSViewer.vue
+++ b/src/components/project/ThreeJSViewer.vue
@@ -382,6 +382,10 @@ function initThreeJS() {
   controls.dynamicDampingFactor = 0.1
   controls.staticMoving = false
 
+  // TrackballControls caches screen dimensions at construction;
+  // recalculate on resize so mouse mapping stays correct.
+  window.addEventListener('resize', onWindowResize)
+
   // Lighting
   setupLighting()
 
@@ -887,18 +891,26 @@ function cleanup() {
   if (controls) {
     controls.dispose()
   }
-  
+
+  window.removeEventListener('resize', onWindowResize)
+
   // Clear loader cache to free memory
   loaderCache.clear()
 }
 
+function onWindowResize() {
+  if (controls) {
+    controls.handleResize()
+  }
+}
+
 // Mouse interaction helpers (for touch devices)
 function onMouseDown(event) {
-  // Handled by OrbitControls
+  // Handled by TrackballControls
 }
 
 function onMouseMove(event) {
-  // Handled by OrbitControls
+  // Handled by TrackballControls
 }
 
 function onMouseUp(event) {

--- a/src/components/project/ThreeJSViewer.vue
+++ b/src/components/project/ThreeJSViewer.vue
@@ -66,7 +66,7 @@
 <script setup>
 import { ref, onMounted, onUnmounted, watch } from 'vue'
 import * as THREE from 'three'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import { TrackballControls } from 'three/examples/jsm/controls/TrackballControls.js'
 
 // Dynamic loader imports for better performance
 const loaderCache = new Map()
@@ -314,9 +314,6 @@ let controls = null
 let currentModel = null
 let animationId = null
 
-// Control states
-const autoRotate = ref(false) // Disabled by default - manual control only
-
 onMounted(() => {
   initThreeJS()
   loadModel()
@@ -356,29 +353,34 @@ function initThreeJS() {
   )
   camera.position.set(5, 5, 5)
 
-  // Renderer
-  renderer = new THREE.WebGLRenderer({ 
-    antialias: true,
-    powerPreference: "high-performance",
-    alpha: false
-  })
+  // Renderer - wrap in try/catch to handle WebGL context failures gracefully
+  try {
+    renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      powerPreference: "high-performance",
+      alpha: false
+    })
+  } catch (e) {
+    error.value = 'WebGL is not available in your browser. Please enable hardware acceleration in your browser settings or try a different browser.'
+    return
+  }
   renderer.setSize(containerWidth, containerHeight)
   renderer.shadowMap.enabled = true
   renderer.shadowMap.type = THREE.PCFSoftShadowMap
-  
+
   // Performance optimizations
   renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
   renderer.outputEncoding = THREE.sRGBEncoding
-  
+
   viewerContainer.value.appendChild(renderer.domElement)
 
-  // Controls
-  controls = new OrbitControls(camera, renderer.domElement)
-  controls.enableDamping = true
-  controls.dampingFactor = 0.05
-  controls.enableZoom = true
-  controls.autoRotate = autoRotate.value
-  controls.autoRotateSpeed = 2.0
+  // Controls - TrackballControls allows full 360° rotation in all axes
+  controls = new TrackballControls(camera, renderer.domElement)
+  controls.rotateSpeed = 5.0
+  controls.zoomSpeed = 1.2
+  controls.panSpeed = 0.8
+  controls.dynamicDampingFactor = 0.1
+  controls.staticMoving = false
 
   // Lighting
   setupLighting()
@@ -428,7 +430,7 @@ function setupLighting() {
 }
 
 async function loadModel() {
-  if (!props.modelUrl || !props.fileExtension) return
+  if (!props.modelUrl || !props.fileExtension || !renderer) return
 
   const signature = `${props.modelUrl}|${props.fileExtension.toLowerCase()}`
 
@@ -824,14 +826,16 @@ function zoomCamera(direction) {
   const direction3D = new THREE.Vector3()
   
   // Get the direction from camera to target
-  direction3D.subVectors(camera.position, controls.target).normalize()
+  direction3D.subVectors(camera.position, controls.target)
+  const distance = direction3D.length()
+  direction3D.normalize()
 
   if (direction === 'in') {
     // Move camera closer to target
-    camera.position.add(direction3D.multiplyScalar(-zoomFactor * controls.getDistance()))
+    camera.position.add(direction3D.multiplyScalar(-zoomFactor * distance))
   } else if (direction === 'out') {
     // Move camera away from target
-    camera.position.add(direction3D.multiplyScalar(zoomFactor * controls.getDistance()))
+    camera.position.add(direction3D.multiplyScalar(zoomFactor * distance))
   }
 
   controls.update()

--- a/src/views/project/media/ListView.vue
+++ b/src/views/project/media/ListView.vue
@@ -1028,7 +1028,13 @@ function getMediaTooltipContent(media_file) {
   if (view && view.name) {
     tooltip += `<strong>View:</strong> ${escapeHtml(view.name)}<br/>`
   }
-  
+
+  if (media_file.is_sided == 1) {
+    tooltip += `<strong>Side:</strong> Left<br/>`
+  } else if (media_file.is_sided == 2) {
+    tooltip += `<strong>Side:</strong> Right<br/>`
+  }
+
   if (taxon) {
     const taxonName = getTaxonName(media_file)
     if (taxonName) {


### PR DESCRIPTION
- Add Left/Right side display to media card hover tooltip in ListView
- Switch 3D viewer from OrbitControls to TrackballControls for full 360° rotation
- Add graceful error handling for WebGL context creation failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching the 3D viewer from `OrbitControls` to `TrackballControls` changes core interaction behavior and could introduce new navigation/zoom edge cases, though changes are localized to the viewer component.
> 
> **Overview**
> Adds *Left/Right side* information to the media hover tooltip in `ListView.vue` when `is_sided` is set.
> 
> Updates `ThreeJSViewer.vue` to use `TrackballControls` for full 360° rotation, handles WebGL renderer creation failures with a user-facing error instead of crashing, and tweaks custom zoom logic to use current camera-to-target distance (instead of `controls.getDistance()`) to stay compatible with the new controls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69fe10d6d62680262c9bb6593757485e6c7c354a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->