### PR TITLE
Add ORCID permission state messaging across publish flow

### DIFF
--- a/src/views/project/publish/FinalView.vue
+++ b/src/views/project/publish/FinalView.vue
@@ -24,7 +24,7 @@ const publicationResult = ref(null)
 const orcidLoginUrl = ref(null)
 
 const showOrcidWriteBanner = computed(() => {
-  return userStore.originalUser?.orcidWriteAccessRequired
+  return userStore.originalUser?.orcidWriteAccessRequired && orcidLoginUrl.value
 })
 
 // Use store-backed unpublished items

--- a/src/views/project/publish/FinalView.vue
+++ b/src/views/project/publish/FinalView.vue
@@ -2,6 +2,8 @@
 import { onMounted, ref, computed, reactive } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { usePublishWorkflowStore } from '@/stores/PublishWorkflowStore.js'
+import { useUserStore } from '@/stores/UserStore.js'
+import { useAuthStore } from '@/stores/AuthStore.js'
 import LoadingIndicator from '@/components/project/LoadingIndicator.vue'
 import UnpublishedItemsNotice from '@/components/project/UnpublishedItemsNotice.vue'
 import PublishedSuccessView from '@/views/project/publish/PublishedSuccessView.vue'
@@ -9,6 +11,8 @@ import PublishedSuccessView from '@/views/project/publish/PublishedSuccessView.v
 const route = useRoute()
 const router = useRouter()
 const publishStore = usePublishWorkflowStore()
+const userStore = useUserStore()
+const authStore = useAuthStore()
 const projectId = route.params.id
 
 const isLoaded = ref(false)
@@ -17,6 +21,11 @@ const errorMessage = ref(null)
 const successMessage = ref(null)
 const publishingComplete = ref(false)
 const publicationResult = ref(null)
+const orcidLoginUrl = ref(null)
+
+const showOrcidWriteBanner = computed(() => {
+  return userStore.originalUser?.orcidWriteAccessRequired
+})
 
 // Use store-backed unpublished items
 const unpublishedItems = computed(() => publishStore.unpublishedItems)
@@ -50,6 +59,16 @@ onMounted(async () => {
     }
   } catch (e) {
     // Best-effort only; ignore errors
+  }
+
+  // Fetch ORCID login URL and user data for banner
+  try {
+    if (!userStore.originalUser?.email) {
+      await userStore.fetchCurrentUser()
+    }
+    orcidLoginUrl.value = await authStore.getOrcidLoginUrl()
+  } catch (e) {
+    // Best-effort; banner just won't show
   }
 
   // Simulate loading delay
@@ -137,6 +156,21 @@ function handleViewPublishedProject(publishedProjectId) {
         <div v-if="errorMessage" class="alert alert-danger" role="alert">
           <i class="fa-solid fa-exclamation-triangle me-2"></i>
           {{ errorMessage }}
+        </div>
+
+        <!-- ORCID Write Access Banner -->
+        <div v-if="showOrcidWriteBanner" class="orcid-publish-banner">
+          <img src="/ORCIDiD_iconvector.svg" class="orcid-banner-icon" alt="ORCID" />
+          <div>
+            <strong>Add this to your ORCID record automatically.</strong>
+            Your ORCID is connected but set to read only. Grant write access and
+            MorphoBank will add published projects to your ORCID profile for you.
+            <a :href="orcidLoginUrl" class="btn btn-sm btn-outline-primary ms-2">
+              Grant Write Access
+            </a>
+            <br />
+            <small class="text-muted">Or continue below — you can always enable this later in your profile settings.</small>
+          </div>
         </div>
 
         <!-- Primary Action Button (centered) -->
@@ -391,6 +425,25 @@ function handleViewPublishedProject(publishedProjectId) {
   padding: 10px;
   border: 2px solid #ededed;
   border-radius: 4px;
+}
+
+.orcid-publish-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 15px;
+  margin-bottom: 20px;
+  background: #d1ecf1;
+  border: 1px solid #bee5eb;
+  border-radius: 8px;
+  color: #0c5460;
+}
+
+.orcid-banner-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  margin-top: 2px;
 }
 
 @media (max-width: 768px) {

--- a/src/views/project/publish/PublishedSuccessView.vue
+++ b/src/views/project/publish/PublishedSuccessView.vue
@@ -22,6 +22,48 @@
       </div>
     </div>
 
+    <!-- ORCID Status Banners -->
+    <!-- Read-only: prompt to grant write access -->
+    <div v-if="orcidState === 'read_only'" class="orcid-banner orcid-banner-info">
+      <img src="/ORCIDiD_iconvector.svg" class="orcid-banner-icon" alt="ORCID" />
+      <div>
+        <strong>Your ORCID record wasn't updated.</strong>
+        MorphoBank can automatically add published projects to your ORCID record — but we need write access first.
+        Grant it once and we'll take care of the rest.
+        <a :href="orcidLoginUrl" class="btn btn-sm btn-outline-primary ms-2">
+          Grant Write Access
+        </a>
+      </div>
+    </div>
+
+    <!-- Pending: async task still running -->
+    <div v-else-if="orcidState === 'pending'" class="orcid-banner orcid-banner-info">
+      <img src="/ORCIDiD_iconvector.svg" class="orcid-banner-icon" alt="ORCID" />
+      <div>
+        <i class="fa-solid fa-spinner fa-spin me-1"></i>
+        Adding this project to your ORCID record...
+      </div>
+    </div>
+
+    <!-- Success: ORCID work created -->
+    <div v-else-if="orcidState === 'success'" class="orcid-banner orcid-banner-success">
+      <img src="/ORCIDiD_iconvector.svg" class="orcid-banner-icon" alt="ORCID" />
+      <div>
+        <strong>Added to your ORCID record.</strong>
+        This project has been automatically added to your ORCID profile.
+      </div>
+    </div>
+
+    <!-- Failed: ORCID API error -->
+    <div v-else-if="orcidState === 'failed'" class="orcid-banner orcid-banner-warning">
+      <img src="/ORCIDiD_iconvector.svg" class="orcid-banner-icon" alt="ORCID" />
+      <div>
+        <strong>Your ORCID record couldn't be updated.</strong>
+        The project was published successfully, but we weren't able to reach ORCID.
+        You can add it manually from your ORCID profile, or we'll try again next time.
+      </div>
+    </div>
+
     <div class="success-actions">
       <button
         v-if="publicationResult?.projectId"
@@ -35,6 +77,11 @@
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue'
+import { useUserStore } from '@/stores/UserStore.js'
+import { useAuthStore } from '@/stores/AuthStore.js'
+import { apiService } from '@/services/apiService.js'
+
 const props = defineProps({
   publicationResult: {
     type: Object,
@@ -43,6 +90,50 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['returnToOverview', 'viewPublishedProject'])
+
+const userStore = useUserStore()
+const authStore = useAuthStore()
+const orcidState = ref(null)
+const orcidLoginUrl = ref(null)
+
+onMounted(async () => {
+  const user = userStore.originalUser
+  if (!user?.orcid) {
+    orcidState.value = 'not_connected'
+    return
+  }
+
+  // orcidWriteAccessRequired accounts for worksEnabled feature flag
+  if (user.orcidWriteAccessRequired) {
+    orcidState.value = 'read_only'
+    orcidLoginUrl.value = await authStore.getOrcidLoginUrl()
+    return
+  }
+
+  // If user has ORCID but no write access and works is disabled, no banner needed
+  if (!user.orcidWriteAccess) {
+    orcidState.value = 'not_connected'
+    return
+  }
+
+  // User has write access — show pending, then poll for actual result
+  orcidState.value = 'pending'
+
+  const projectId = props.publicationResult?.projectId
+  if (!projectId) return
+
+  setTimeout(async () => {
+    try {
+      const response = await apiService.get(
+        `/projects/${projectId}/publishing/orcid-status`
+      )
+      const data = await response.json()
+      orcidState.value = data.orcidState
+    } catch (e) {
+      orcidState.value = 'failed'
+    }
+  }, 8000)
+})
 
 function formatDate(timestamp) {
   if (!timestamp) return ''
@@ -79,7 +170,7 @@ function formatDate(timestamp) {
 }
 
 .success-details {
-  margin-bottom: 40px;
+  margin-bottom: 20px;
 }
 
 .success-details p {
@@ -106,6 +197,43 @@ function formatDate(timestamp) {
 .info-item strong {
   color: #333;
   margin-right: 8px;
+}
+
+/* ORCID Banner Styles */
+.orcid-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 15px;
+  border-radius: 8px;
+  text-align: left;
+  max-width: 600px;
+  margin: 0 auto 30px auto;
+}
+
+.orcid-banner-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.orcid-banner-info {
+  background: #d1ecf1;
+  border: 1px solid #bee5eb;
+  color: #0c5460;
+}
+
+.orcid-banner-success {
+  background: #d4edda;
+  border: 1px solid #c3e6cb;
+  color: #155724;
+}
+
+.orcid-banner-warning {
+  background: #fff3cd;
+  border: 1px solid #ffeaa7;
+  color: #856404;
 }
 
 .success-actions {

--- a/src/views/project/publish/PublishedSuccessView.vue
+++ b/src/views/project/publish/PublishedSuccessView.vue
@@ -24,7 +24,7 @@
 
     <!-- ORCID Status Banners -->
     <!-- Read-only: prompt to grant write access -->
-    <div v-if="orcidState === 'read_only'" class="orcid-banner orcid-banner-info">
+    <div v-if="orcidState === 'read_only' && orcidLoginUrl" class="orcid-banner orcid-banner-info">
       <img src="/ORCIDiD_iconvector.svg" class="orcid-banner-icon" alt="ORCID" />
       <div>
         <strong>Your ORCID record wasn't updated.</strong>
@@ -116,17 +116,24 @@ onMounted(async () => {
     return
   }
 
-  // User has write access — show pending, then poll for actual result
-  orcidState.value = 'pending'
-
+  // User has write access — poll backend for actual result
   const projectId = props.publicationResult?.projectId
-  if (!projectId) return
+  if (!projectId) {
+    orcidState.value = 'not_connected'
+    return
+  }
+
+  orcidState.value = 'pending'
 
   setTimeout(async () => {
     try {
       const response = await apiService.get(
         `/projects/${projectId}/publishing/orcid-status`
       )
+      if (!response.ok) {
+        orcidState.value = 'failed'
+        return
+      }
       const data = await response.json()
       orcidState.value = data.orcidState
     } catch (e) {

--- a/src/views/project/publish/PublishedSuccessView.vue
+++ b/src/views/project/publish/PublishedSuccessView.vue
@@ -124,23 +124,30 @@ onMounted(async () => {
   }
 
   orcidState.value = 'pending'
+  pollOrcidStatus(projectId)
+})
+
+async function pollOrcidStatus(projectId, attempt = 1) {
+  const maxAttempts = 3
+  const delay = attempt === 1 ? 8000 : 5000
 
   setTimeout(async () => {
     try {
       const response = await apiService.get(
         `/projects/${projectId}/publishing/orcid-status`
       )
-      if (!response.ok) {
-        orcidState.value = 'failed'
-        return
-      }
       const data = await response.json()
-      orcidState.value = data.orcidState
+
+      if (data.orcidState === 'pending' && attempt < maxAttempts) {
+        pollOrcidStatus(projectId, attempt + 1)
+      } else {
+        orcidState.value = data.orcidState
+      }
     } catch (e) {
       orcidState.value = 'failed'
     }
-  }, 8000)
-})
+  }, delay)
+}
 
 function formatDate(timestamp) {
   if (!timestamp) return ''

--- a/src/views/users/UserProfileView.vue
+++ b/src/views/users/UserProfileView.vue
@@ -538,6 +538,9 @@ const submitButtonText = computed(() => {
             When checked, MorphoBank will not push any published works to your ORCID record.
             You can also opt out on a per-project basis from each project's overview page.
           </p>
+          <p class="field-description text-muted" style="font-size: 0.85em;">
+            MorphoBank will only ever add projects you publish. You can revoke access at any time from your ORCID settings.
+          </p>
         </div>
 
         <div class="form-buttons">


### PR DESCRIPTION
- Profile page: add reassurance text below ORCID opt-out checkbox
- Publish confirmation: show info banner when ORCID is read-only, prompting users to grant write access (does not block publishing)
- Post-publish: show contextual ORCID status banners (pending, success, failed, read-only) with polling for async task result

Uses orcidWriteAccessRequired field to respect worksEnabled feature flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new ORCID-dependent UI and client-side polling to the post-publish screen, which could introduce regressions if user/auth state is missing or the new status endpoint behaves unexpectedly. Publishing itself remains unchanged and ORCID logic is best-effort/non-blocking.
> 
> **Overview**
> Improves ORCID messaging across the publish experience by showing a **non-blocking** banner on the final publish confirmation step when the user’s ORCID connection is *read-only*, including a `getOrcidLoginUrl()` link to grant write access.
> 
> Enhances the post-publish success screen with contextual ORCID status banners (`read_only`, `pending`, `success`, `failed`) and a short polling loop against `GET /projects/{id}/publishing/orcid-status` to reflect the async ORCID update outcome.
> 
> Adds a small reassurance note under the ORCID opt-out checkbox in the user profile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bbe15284685c6990c65dda43c3f10327354029c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->