### PR TITLE
Release 20260423

### DIFF
--- a/src/components/media/AnnotationViewer.vue
+++ b/src/components/media/AnnotationViewer.vue
@@ -862,9 +862,9 @@ export default {
         this._containerResizeObserver.disconnect()
         this._containerResizeObserver = null
       }
-      if (this._annotationResizeRaf != null) {
-        cancelAnimationFrame(this._annotationResizeRaf)
-        this._annotationResizeRaf = null
+      if (this._containerResizeRaf != null) {
+        cancelAnimationFrame(this._containerResizeRaf)
+        this._containerResizeRaf = null
       }
       if (this._roFallbackTimer) {
         clearTimeout(this._roFallbackTimer)

--- a/src/components/media/AnnotationViewer.vue
+++ b/src/components/media/AnnotationViewer.vue
@@ -734,7 +734,6 @@ export default {
       if (this.$refs.mediaImage) {
         this.updateImageTransform()
       }
-      this.syncImageIfAlreadyDecoded()
     }, 50)
     
     // Watch for refs to become available
@@ -747,6 +746,11 @@ export default {
         }
       }
       checkRefs()
+    })
+
+    // Re-run layout when the modal body gets a non-zero size (cached images can decode before this).
+    this.$nextTick(() => {
+      this.setupAnnotationContainerSizeObserver()
     })
   },
 
@@ -794,7 +798,6 @@ export default {
           }
         })
         
-        // Cache-complete images may never fire <img> @load; dismiss overlay and init canvas
         this.syncImageIfAlreadyDecoded()
       },
       immediate: true
@@ -802,6 +805,7 @@ export default {
   },
 
   beforeUnmount() {
+    this.teardownAnnotationContainerSizeObserver()
     this.removeEventListeners()
     this.clearImageLoadTimer()
     this.cleanupTiffBlobUrl()
@@ -823,6 +827,49 @@ export default {
       document.removeEventListener('mousemove', this.onDocumentMouseMove)
       document.removeEventListener('mouseup', this.onDocumentMouseUp)
       window.removeEventListener('resize', this.onWindowResize)
+    },
+
+    // Re-layout when the viewing area gets real dimensions (e.g. matrix modal after animation).
+    setupAnnotationContainerSizeObserver() {
+      this.teardownAnnotationContainerSizeObserver()
+      const el = this.$refs.canvasContainer
+      if (!el) {
+        return
+      }
+      if (typeof ResizeObserver === 'undefined') {
+        this._roFallbackTimer = setTimeout(() => this.syncCanvasToCurrentImage(), 200)
+        return
+      }
+      this._containerResizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          if (entry.contentRect.width < 1 || entry.contentRect.height < 1) {
+            continue
+          }
+          if (this._containerResizeRaf != null) {
+            cancelAnimationFrame(this._containerResizeRaf)
+          }
+          this._containerResizeRaf = requestAnimationFrame(() => {
+            this._containerResizeRaf = null
+            this.syncCanvasToCurrentImage()
+          })
+        }
+      })
+      this._containerResizeObserver.observe(el)
+    },
+
+    teardownAnnotationContainerSizeObserver() {
+      if (this._containerResizeObserver) {
+        this._containerResizeObserver.disconnect()
+        this._containerResizeObserver = null
+      }
+      if (this._annotationResizeRaf != null) {
+        cancelAnimationFrame(this._annotationResizeRaf)
+        this._annotationResizeRaf = null
+      }
+      if (this._roFallbackTimer) {
+        clearTimeout(this._roFallbackTimer)
+        this._roFallbackTimer = null
+      }
     },
 
     toggleHelp() {
@@ -1105,11 +1152,7 @@ export default {
       this.showSaveStatus('Failed to load image (tried original and large versions)', 'error')
     },
 
-    /**
-     * If the <img> already has decodeable pixels (e.g. served from the HTTP cache when the
-     * same file is opened again in a different cell), the load event can fire before @load
-     * is bound or not fire at all. Without onImageLoad, the loading overlay never dismisses.
-     */
+    // If the <img> is already decoded (cache), @load may not run—still run the same init as onImageLoad.
     syncImageIfAlreadyDecoded() {
       this.$nextTick(() => {
         this.tryRunImageLoadFromDecodableImage()
@@ -1133,8 +1176,10 @@ export default {
       this.onImageLoad()
     },
 
-    /** Re-layout canvas if the image is already fully loaded (used after idempotent onImageLoad). */
     syncCanvasToCurrentImage() {
+      if (!this.imageLoaded) {
+        return
+      }
       this.$nextTick(() => {
         this.setupCanvas()
         this.updateImageTransform()
@@ -1158,6 +1203,11 @@ export default {
       
       if (naturalWidth === 0 || naturalHeight === 0) {
         // Image not fully loaded yet
+        return
+      }
+
+      // Modal (e.g. matrix ImageViewer) may not have been laid out yet; skip until we have a real box
+      if (containerWidth < 1 || containerHeight < 1) {
         return
       }
       
@@ -2405,10 +2455,10 @@ export default {
         // Emit event for parent component
         this.$emit('annotationsLoaded', this.annotations.length)
         
-        // Draw annotations on canvas
         this.$nextTick(() => {
-          this.drawAnnotations()
-          
+          if (this.imageLoaded) {
+            this.syncCanvasToCurrentImage()
+          }
           // Wait for image to load before forcing label update
           setTimeout(() => {
             if (this.$refs.mediaImage && this.$refs.canvasContainer) {

--- a/src/components/media/AnnotationViewer.vue
+++ b/src/components/media/AnnotationViewer.vue
@@ -734,6 +734,7 @@ export default {
       if (this.$refs.mediaImage) {
         this.updateImageTransform()
       }
+      this.syncImageIfAlreadyDecoded()
     }, 50)
     
     // Watch for refs to become available
@@ -792,6 +793,9 @@ export default {
             this.updateImageTransform()
           }
         })
+        
+        // Cache-complete images may never fire <img> @load; dismiss overlay and init canvas
+        this.syncImageIfAlreadyDecoded()
       },
       immediate: true
     }
@@ -1034,6 +1038,13 @@ export default {
         return
       }
       
+      // Deduplicate: the same <img> can fire @load and also be completed synchronously
+      // from the browser cache (re-opening the same media in another cell).
+      if (this.imageLoaded) {
+        this.syncCanvasToCurrentImage()
+        return
+      }
+      
       this.imageLoaded = true
       this.isLoadingImage = false
       this.clearImageLoadTimer()
@@ -1086,11 +1097,49 @@ export default {
         this.imageLoaded = false
         this.isLoadingImage = true
         this.startImageLoadWatch()
+        this.syncImageIfAlreadyDecoded()
         return
       }
       
       // If fallback also failed, show error
       this.showSaveStatus('Failed to load image (tried original and large versions)', 'error')
+    },
+
+    /**
+     * If the <img> already has decodeable pixels (e.g. served from the HTTP cache when the
+     * same file is opened again in a different cell), the load event can fire before @load
+     * is bound or not fire at all. Without onImageLoad, the loading overlay never dismisses.
+     */
+    syncImageIfAlreadyDecoded() {
+      this.$nextTick(() => {
+        this.tryRunImageLoadFromDecodableImage()
+        requestAnimationFrame(() => {
+          this.tryRunImageLoadFromDecodableImage()
+        })
+      })
+    },
+
+    tryRunImageLoadFromDecodableImage() {
+      if (this.isLoadingTiff) {
+        return
+      }
+      const img = this.$refs.mediaImage
+      if (!img || !img.complete) {
+        return
+      }
+      if (img.naturalWidth < 1 || img.naturalHeight < 1) {
+        return
+      }
+      this.onImageLoad()
+    },
+
+    /** Re-layout canvas if the image is already fully loaded (used after idempotent onImageLoad). */
+    syncCanvasToCurrentImage() {
+      this.$nextTick(() => {
+        this.setupCanvas()
+        this.updateImageTransform()
+        this.drawAnnotations()
+      })
     },
 
     setupCanvas() {
@@ -2884,6 +2933,7 @@ export default {
           this.isLoadingImage = true
           this.imageLoaded = false
           this.clearImageLoadTimer()
+          this.syncImageIfAlreadyDecoded()
         }
       }, this.fallbackDelayMs)
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches image-load and layout timing in `AnnotationViewer.vue`, which can affect whether annotations/canvas render or sync correctly across modal animations and cached image loads. Risk is moderate because it adds ResizeObserver/RAF logic and new init paths that are timing-sensitive across browsers.
> 
> **Overview**
> Improves `AnnotationViewer` reliability when opened in modals and when images come from browser cache by **re-syncing canvas/transform/annotation drawing** whenever the container gains real dimensions and when an `<img>` is already decoded (so `@load` may not fire).
> 
> Adds a `ResizeObserver` (with timer fallback) to trigger relayout, deduplicates repeated `onImageLoad` calls, and centralizes redraw via `syncCanvasToCurrentImage()`, while also guarding `setupCanvas()` from running when the container is still `0x0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c4ba00a96183f0cdbc09ef5b19f800c00acefcf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->