### PR TITLE
MB4-448: Preserve matrix scores when AI character extractor runs

### DIFF
--- a/src/views/project/matrices/CreateView.vue
+++ b/src/views/project/matrices/CreateView.vue
@@ -610,18 +610,11 @@ function convertNewlines(text) {
 // Handle characters extracted from AI
 function handleCharactersExtracted(extractedCharacters) {
   isAiExtracted.value = true
-  // Track whether the matrix had named characters before this extraction.
-  // If not, the cells from the MATRIX block are for unnamed/declared characters
-  // and don't correspond to the AI-extracted characters — they must be cleared.
-  const hadNamedCharacters = importedMatrix.characters && importedMatrix.characters.size > 0
 
   // Initialize characters Map if it doesn't exist
   if (!importedMatrix.characters) {
     importedMatrix.characters = new Map()
   }
-
-  // Track the initial character count to calculate actual new characters added
-  const initialCharCount = importedMatrix.characters.size
 
   // Add each extracted character to the importedMatrix, deduplicating names
   // to prevent Map.set from overwriting existing entries (which would corrupt
@@ -640,9 +633,6 @@ function handleCharactersExtracted(extractedCharacters) {
     }
     importedMatrix.characters.set(insertName, character)
   }
-
-  // Calculate the actual number of new characters added (not overwritten)
-  const newCharCount = importedMatrix.characters.size - initialCharCount
 
   // Normalize cells to match taxa:
   // The parser may create phantom cell entries (e.g. when NCHAR dimension is missing
@@ -675,41 +665,28 @@ function handleCharactersExtracted(extractedCharacters) {
       }
     }
     importedMatrix.cells = normalizedCells
-
-    // If the matrix had no named characters before, the existing cell data is from
-    // the MATRIX block's unnamed/declared characters and doesn't correspond to the
-    // AI-extracted characters. Clear it so padding creates clean '?' rows.
-    if (!hadNamedCharacters) {
-      for (const taxonKey of importedMatrix.cells.keys()) {
-        importedMatrix.cells.set(taxonKey, [])
-      }
-    } else {
-      // The parser pads cell rows to NCHAR (declared dimension). For
-      // UNDEFINED_CHARACTERS matrices NCHAR > characters.size, so rows are
-      // longer than the named-character count. Trim them to initialCharCount
-      // now; the padding loop below will then bring every row to exactly
-      // initialCharCount + newCharCount == characters.size.
-      for (const taxonKey of importedMatrix.cells.keys()) {
-        const row = importedMatrix.cells.get(taxonKey)
-        if (row.length > initialCharCount) {
-          importedMatrix.cells.set(taxonKey, row.slice(0, initialCharCount))
-        }
-      }
-    }
   }
 
-  // Pad every taxon's cell row with '?' for each newly added character
-  // so the matrix dimensions stay consistent (cells per row == total characters)
+  // Reconcile cell row width with the total character count. The .nex MATRIX
+  // block scores correspond positionally to the AI-extracted characters (that
+  // is the whole point of AI extraction — name the unnamed/declared columns),
+  // so existing cell data must be preserved. Pad rows shorter than the new
+  // total with the missing symbol; trim defensively if any row exceeds it.
+  // (MB4-448: prior logic cleared all rows when characters.size was 0 before
+  // extraction, which is exactly the AI-extractor flow — wiping every score.)
   if (importedMatrix.cells) {
     const missingSymbol = importedMatrix.parameters?.MISSING ?? '?'
+    const targetLength = importedMatrix.characters.size
     for (const cellKey of importedMatrix.cells.keys()) {
       const cellRow = importedMatrix.cells.get(cellKey)
-      for (let i = 0; i < newCharCount; i++) {
+      while (cellRow.length < targetLength) {
         cellRow.push(new Cell(missingSymbol))
+      }
+      if (cellRow.length > targetLength) {
+        importedMatrix.cells.set(cellKey, cellRow.slice(0, targetLength))
       }
     }
   }
-
 }
 
 // Handle extraction errors


### PR DESCRIPTION
## Summary

Frontend half of the MB4-448 fix. Pairs with mb4-service PR #371 (merged).

`handleCharactersExtracted` previously cleared every cell row when `importedMatrix.characters.size === 0` before extraction — which is the *defining* condition of the AI-extractor flow (user uploads a `.nex` with NCHAR scored columns but no CHARLABELS, then provides a PDF naming those columns). Result: the MATRIX-block scores were always wiped to `?` before upload.

This change replaces the clear/trim/pad branches with a single width-aware reconciler that pads short rows with `?` and trims over-long rows to `characters.size`, so the positionally-aligned cells from the `.nex` MATRIX block survive intact.

## Test plan

- [x] Reproduced on beta with `Turrilitoidea_Monks_1999.nex` + Monks 2003 PDF (Tanya's case from MB4-448): before fix, every cell `?`; after fix, score digits land in `importedMatrix.cells` and reach the backend.
- [ ] After mb4-service PR #371 lands, deploy both via `release/*` to beta — confirm cols 2–5 show `State 2` / `State 3` placeholders, other columns show real digits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes matrix import reconciliation logic during AI character extraction, which can affect persisted matrix scoring data if row-width assumptions are wrong. Scope is limited to `handleCharactersExtracted` but touches core data-shaping before upload.
> 
> **Overview**
> Fixes the AI character-extraction flow so existing `.nex` MATRIX-block scores are **preserved** instead of being cleared to missing values when the upload initially has zero named characters.
> 
> Replaces the prior clear/trim/pad branching with a single reconciliation step that normalizes `cells` to `taxa`, then *pads or trims* each taxon’s cell row to `characters.size` using the configured missing symbol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c8e12b783d00ae8f0f08cf92dd60d2238c92e60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->