### PR TITLE
MB4-453: Fix folio redirect and media loading on direct URL

### DIFF
--- a/src/router/oldMappingReroute.js
+++ b/src/router/oldMappingReroute.js
@@ -373,9 +373,9 @@ export const legacyRoutes = [
       const folioId = to.query.folio_id
       if (projectId && /^\d+$/.test(projectId)) {
         if (folioId && /^\d+$/.test(folioId)) {
-          return `/project/${projectId}/folios/${folioId}`
+          return { path: `/project/${projectId}/folios/${folioId}`, query: {} }
         }
-        return `/project/${projectId}/folios`
+        return { path: `/project/${projectId}/folios`, query: {} }
       }
       return '/projects/journal_year'
     },

--- a/src/router/oldMappingReroute.js
+++ b/src/router/oldMappingReroute.js
@@ -359,12 +359,26 @@ export const legacyRoutes = [
     redirect: createProjectRedirect('/project/:projectId/bibliography', '/projects/journal_year'),
   },
   {
+    path: '/Projects/FoliosList/folio_id/:folioId/project_id/:projectId',
+    redirect: (to) => `/project/${to.params.projectId}/folios/${to.params.folioId}`,
+  },
+  {
     path: '/Projects/FoliosList/project_id/:projectId',
     redirect: (to) => `/project/${to.params.projectId}/folios`,
   },
   {
     path: '/Projects/FoliosList',
-    redirect: createProjectRedirect('/project/:projectId/folios', '/projects/journal_year'),
+    redirect: (to) => {
+      const projectId = to.query.project_id
+      const folioId = to.query.folio_id
+      if (projectId && /^\d+$/.test(projectId)) {
+        if (folioId && /^\d+$/.test(folioId)) {
+          return `/project/${projectId}/folios/${folioId}`
+        }
+        return `/project/${projectId}/folios`
+      }
+      return '/projects/journal_year'
+    },
   },
 
   // Unimplemented published project pages

--- a/src/views/project/published/FolioDetailView.vue
+++ b/src/views/project/published/FolioDetailView.vue
@@ -15,28 +15,36 @@ const projectId = route.params.id
 const folioId = route.params.folioId
 const folioInfo = ref(null)
 const mediaFiles = ref(null)
+const loading = ref(true)
+const error = ref(null)
 
-onMounted(() => {
-  projectStore
-    .fetchProject(projectId)
-    .then(() => {
-      folioInfo.value = projectStore.getFolioInfo(folioId)
-    })
-    .then(() => {
-      mediaStore.fetchMediaFiles(projectId).then(() => {
-        mediaFiles.value = mediaStore.getMediaFilesByIdList(
-          folioInfo.value?.media_files
-        )
+onMounted(async () => {
+  try {
+    await projectStore.fetchProject(projectId)
+    folioInfo.value = projectStore.getFolioInfo(folioId)
+
+    if (!folioInfo.value) {
+      error.value = `Folio F${folioId} not found in this project.`
+      return
+    }
+
+    await mediaStore.fetchMediaFiles(projectId)
+    mediaFiles.value = mediaStore.getMediaFilesByIdList(
+      folioInfo.value?.media_files
+    )
+
+    if (projectId && folioId) {
+      logView({
+        project_id: projectId,
+        hit_type: HIT_TYPES.FOLIO,
+        row_id: folioId,
       })
-    })
-
-  // Track folio view only when there's a specific folio ID
-  if (projectId && folioId) {
-    logView({
-      project_id: projectId,
-      hit_type: HIT_TYPES.FOLIO,
-      row_id: folioId,
-    })
+    }
+  } catch (e) {
+    console.error('Error loading folio detail:', e)
+    error.value = 'Error loading folio media.'
+  } finally {
+    loading.value = false
   }
 })
 
@@ -47,8 +55,8 @@ function generateFoliosListRoute() {
 
 <template>
   <ProjectLoaderComp
-    :isLoading="mediaStore.isLoading"
-    :errorMessage="mediaStore.media_files ? null : 'No media data available.'"
+    :isLoading="loading"
+    :errorMessage="error"
     basePath="project"
   >
     <p>


### PR DESCRIPTION
## Summary

- Add missing legacy redirect for `/Projects/FoliosList/folio_id/:folioId/project_id/:projectId` → `/project/:projectId/folios/:folioId` (old PHP v3 URL pattern)
- Extended the query-param redirect form to also handle `?folio_id=` alongside `?project_id=`
- Fix `FolioDetailView` media not loading when navigating directly to a folio URL — replaced `mediaStore.isLoading` (starts `false`) with a local `loading = ref(true)` and rewrote with `async/await`, matching the pattern already used in `MediaDetailView`

## Test plan

- [x] Visit `/Projects/FoliosList/folio_id/882/project_id/3190` — should redirect to `/project/3190/folios/882`
- [x] Visit `/Projects/FoliosList?folio_id=882&project_id=3190` — should redirect to `/project/3190/folios/882`
- [x] Paste `/project/3190/folios/882` directly into a new browser window — media should load and display
- [x] Click a folio link from `/project/3190/folios` — media should still load and display

Fixes: [MB4-453](https://phoenixbioinformatics.atlassian.net/browse/MB4-453)
Hotfix branched from: `production-release-2026-05-12-001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to legacy URL redirect logic and folio detail loading state, with minimal impact outside routing and one view. Main risk is potential mis-redirect if query params are malformed, but inputs are validated as numeric.
> 
> **Overview**
> Fixes legacy folio URLs by adding a missing redirect for `/Projects/FoliosList/folio_id/:folioId/project_id/:projectId` and enhancing the `/Projects/FoliosList` redirect to also honor `folio_id` (in addition to `project_id`) when provided via query params.
> 
> Updates `FolioDetailView.vue` to reliably load folio media on direct navigation by switching to `async/await`, introducing local `loading`/`error` state, handling “folio not found”, and wiring `ProjectLoaderComp` to these new states (while keeping analytics logging after successful load).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 627b21d4f4ce9606e54a8269244e70e8a1594b95. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->